### PR TITLE
Updated README.md to include a note about tdfriendselector.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Just edit `example.js` and set your Facebook `appId`.
 ### Include required CSS
 
 - Include the `tdfriendselector.css` stylesheet in your document.
+- Ensure `tdfriendselector.png` is located in the same directory as `tdfriendselector.css`
 - We wrote the stylesheet with Sass and have included the SCSS source.
 
 ### Include required JavaScript


### PR DESCRIPTION
The `tdfriendselector.png` file was not meantioned in the README. It is used for the next/prev buttons. Some new users might not notice it's missing (since missing CSS background images render as transparent). Added a note to the README to make it part of the setup process.
